### PR TITLE
Fix issues with IIS-based responses

### DIFF
--- a/src/giaeConnect.php
+++ b/src/giaeConnect.php
@@ -114,16 +114,19 @@ class GiaeConnect {
         } else {
             $cookieValue = null;
             if (preg_match('/\b' . "sessao" . '\s*=\s*([^;]+)/i', $response, $matches)) {
-                $cookieValue = $matches[1];
-                // Find the position of the first space
-                $firstSpacePos = strpos($cookieValue, 'content-length:');
+            $cookieValue = $matches[1];
+            // Find the position of the first occurrence of 'content-length:' or 'Content-Length:'
+            $firstSpacePos = stripos($cookieValue, 'content-length:');
+            if ($firstSpacePos === false) {
+                $firstSpacePos = stripos($cookieValue, 'Content-Length:');
+            }
 
-                if ($firstSpacePos !== false) {
-                    // Extract the part of the cookie value before the first space
-                    $modifiedValue = substr($cookieValue, 0, $firstSpacePos);
-                    $session = substr($modifiedValue, 0, -2) . ";";
-                    return $session;
-                }
+            if ($firstSpacePos !== false) {
+                // Extract the part of the cookie value before the first occurrence
+                $modifiedValue = substr($cookieValue, 0, $firstSpacePos);
+                $session = substr($modifiedValue, 0, -2) . ";";
+                return $session;
+            }
             }
         }
         

--- a/src/giaeConnect.php
+++ b/src/giaeConnect.php
@@ -116,7 +116,7 @@ class GiaeConnect {
             if (preg_match('/\b' . "sessao" . '\s*=\s*([^;]+)/i', $response, $matches)) {
                 $cookieValue = $matches[1];
                 // Find the position of the first space
-                $firstSpacePos = strpos($cookieValue, 'Content-Length:');
+                $firstSpacePos = strpos($cookieValue, 'content-length:');
 
                 if ($firstSpacePos !== false) {
                     // Extract the part of the cookie value before the first space


### PR DESCRIPTION
IIS-based responses seem to break the code for getting sessions due to the hacky way it was created (because it used an Apache response as a base)

This patch fixes the issue with IIS-based responses, but will also break the IIS-based responses, meaning the get session method should be updated to include both responses (as concluded in #1).