### PR TITLE
Add getPerfil for profile function in GIAE

### DIFF
--- a/src/giaeConnect.php
+++ b/src/giaeConnect.php
@@ -495,6 +495,14 @@ class GiaeConnect {
 
     }
 
+    public function getPerfil(){
+
+        $payload = json_encode([
+            "acao"=>"get_perfil"
+        ]);
+
+        return $this->post("perfil", $payload);
+    }
 }
 
 ?>


### PR DESCRIPTION
Hey @itsjuoum. Recently while finding new ways to improve my latest project FormFill, I've found a new function (or that I haven't previously noticed) function in GIAE for "Perfil". This option allows me to get both the email associated with the user, and their full name, which lets me store them in a DB for future action (like notifications, etc...)

![imagem](https://github.com/user-attachments/assets/1bc9188a-71a5-4ba7-9b4e-fac960d598dc)

I've added the missing function to GIAEConnect and it works, as seen in the screenshot below. Glad to be improving this amazing project (which has helped me A LOT).
![imagem](https://github.com/user-attachments/assets/a5d88bda-368e-4fc3-9570-e5471cd6b523)
